### PR TITLE
test: load dotenv on conftest module levle

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
         args: [] # optional: list of Conventional Commits types to allow
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
-    rev: v0.7.3
+    rev: v0.11.13
     hooks:
       # Run the linter.
       - id: ruff

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -183,9 +183,9 @@ def dummy_string_dataset_id(
 
 
 @fixture
-def sequence_examples() -> (
-    Iterable[Example[DummyStringInput, DummyStringExpectedOutput]]
-):
+def sequence_examples() -> Iterable[
+    Example[DummyStringInput, DummyStringExpectedOutput]
+]:
     return [
         Example(
             input=DummyStringInput(input="success"),


### PR DESCRIPTION
- when running the tests in parallel the dotenv sometimes would not be correctly loaded from the dotenv, this most likely happens because of some dependency of the AA_TOKEN that does not depend on the fixture `token`