### PR TITLE
chore: explicitly set "feat, chore, fix, docs, refactor, test, build,…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
     hooks:
       - id: conventional-pre-commit
         stages: [commit-msg]
-        args: [] # optional: list of Conventional Commits types to allow
+        args: [feat, chore, fix, docs, refactor, test, build, ci, deps, style]
   - repo: https://github.com/astral-sh/ruff-pre-commit
     # Ruff version.
     rev: v0.11.13


### PR DESCRIPTION
… ci, deps, style" as commit prefixes, so release-please can read them