### PR TITLE
feat: add parameter max_workers to StudioBenchmark.execute

### DIFF
--- a/pharia_studio_sdk/evaluation/benchmark/studio_benchmark.py
+++ b/pharia_studio_sdk/evaluation/benchmark/studio_benchmark.py
@@ -98,6 +98,7 @@ class StudioBenchmark(Benchmark):
         description: str | None = None,
         labels: set[str] | None = None,
         metadata: dict[str, Any] | None = None,
+        max_workers: int = 10,
     ) -> str:
         start = datetime.now(timezone.utc)
 
@@ -108,7 +109,11 @@ class StudioBenchmark(Benchmark):
             f"benchmark-{self.id}-runner",
         )
         run_overview = runner.run_dataset(
-            self.dataset_id, description=description, labels=labels, metadata=metadata
+            self.dataset_id,
+            description=description,
+            labels=labels,
+            metadata=metadata,
+            max_workers=max_workers,
         )
 
         evaluation_overview = self.evaluator.evaluate_runs(


### PR DESCRIPTION
* add parameter max_workers to StudioBenchmark.execute
* to allow the control of parallel executions of various runs
   - needed when too many requests clog the inference API
* default set to 10 for simple extension of functionality

This corresponds to commit 261ab36a28977d91e2d0c8ca16039edcbab81925 in intelligence-layer-sdk